### PR TITLE
Update DSiWare guide

### DIFF
--- a/docs/tutorials/dsiware.md
+++ b/docs/tutorials/dsiware.md
@@ -42,11 +42,11 @@ By following either method, nds-bootstrap will be installed in order to run DSiW
 
 === "Flashcart Kernels"
 
-    1. Download [NDSForwarder-DSi](https://github.com/lifehackerhansol/NDSForwarder-DSi/releases/latest/download/NDSForwarder.nds) to the flashcart's SD card root
+    1. Download [NDSForwarder-DSi](https://github.com/lifehackerhansol/NDSForwarder-DSi/releases/latest/download/NDSForwarder.nds) to the flashcart's SD card root.
 
-    1. Download the [nds-bootstrap forwarder pack](https://github.com/RocketRobz/NTR_Forwarder/releases/latest/download/DS.Game.Forwarder.pack.nds-bootstrap.7z)
+    1. Download the [nds-bootstrap forwarder pack](https://github.com/RocketRobz/NTR_Forwarder/releases/latest/download/DS.Game.Forwarder.pack.nds-bootstrap.7z).
 
-    1. Extract the contents of the `for SD Card root` folder to the root of your flashcart's SD card
+    1. Extract the contents of the `for SD Card root` folder to the root of your flashcart's SD card.
 
     1. After setting up the nds-bootstrap forwarder pack, you will need to place your DSiWare (with `.nds` extension) in `/roms/dsi` on your SD card.
 
@@ -62,9 +62,9 @@ By following either method, nds-bootstrap will be installed in order to run DSiW
 
     === "Setting a Donor ROM"
 
-        1. Launch `NDSForwarder.nds`
+        1. Launch `NDSForwarder.nds`.
 
-        1. Press `A` on `Install`
+        1. Press `A` on `Install`.
 
         1. Navigate to the donor game's location, press `A`, and select `Install`.
 
@@ -74,9 +74,9 @@ By following either method, nds-bootstrap will be installed in order to run DSiW
 
     === "Adding a DSiWare title"
 
-        1. Launch `NDSForwarder.nds`
+        1. Launch `NDSForwarder.nds`.
 
-        1. Press `A` on `Install`
+        1. Press `A` on `Install`.
 
         1. Navigate to the DSiWare's location, press `A`, and select `Install`.
 

--- a/docs/tutorials/dsiware.md
+++ b/docs/tutorials/dsiware.md
@@ -7,31 +7,79 @@ title: Running DSiWare On Flashcarts
 
 !!! warning "DSiWare Compatibility"
 
-    Runnning DSiWare on NDS hardware is not a stable experience. As DSiWare is meant to run in DSi mode with larger RAM and higher clock speeds than NDS, you will sometimes run into slowdown or outright game crashes. A Memory Expansion Pak may also be required to run some DSiWare in NDS mode. For example, *Zelda: Four Swords* will not launch on a DS unless the pak is inserted.
+    Running DSiWare on NDS hardware is not a stable experience. As DSiWare is meant to run in DSi mode with larger RAM and higher clock speeds than NDS, some titles will run with no audio playback and/or outright crash later on, with a few that will occasionally run with slowdown. A Memory Expansion Pak may also be required to run some DSiWare in NDS mode. For example, *Dragon Quest Wars* will not launch on a DS unless the pak is inserted.
 
     A list of DS-mode compatible DSiWare can be found in the [TWiLight Menu++ GitHub Repository](https://github.com/DS-Homebrew/TWiLightMenu/blob/master/universal/include/compatibleDSiWareMap.h).
 
 ### Setup Guide:
 
-1. TWiLight Menu++ and NDS-Bootstrap is required to run DSiWare. As such, first setup TWiLight as either [primary](twilight.md) or [secondary](twilight-dualboot.md) kernel on your flashcart.
+By following either method, nds-bootstrap will be installed in order to run DSiWare.
 
-1. After setting up TWiLight Menu++, you will need to place your DSiWare (with `.nds` extension) in `/roms/dsiware` on your SD card.
+=== "TWiLight Menu++"
 
-    !!! note
+    1. First setup TWiLight as either [primary](twilight.md) or [secondary](twilight-dualboot.md) kernel on your flashcart.
 
-        If your DSiWare dump is a file with no file extension, you can change the filename and add `.nds` to the end to get TWiLight Menu++ to pick it up in the menu.
+    1. After setting up TWiLight Menu++, you will need to place your DSiWare (with `.nds` extension) in `/roms/dsi` on your SD card.
 
-        For example, if you have a DSiWare dump of *Zelda: Four Swords* with the filename `00000000`, you can rename the file to `Zelda Four Swords.nds`, before placing it inside `/roms/dsiware`
+        !!! note
 
-1. You will now need to find a DS game built with SDK 5.x to use as a donor ROM for DSiWare. Place the donor ROM in `/roms/nds`.
+            If your DSiWare dump is a file with no file extension, you can change the filename and add `.nds` to the end to get TWiLight Menu++ to pick it up in the menu.
 
-    !!! tip
-        ![SDK5](../images/donor_info.png){align=left width="115"}
+            For example, if you have a DSiWare dump of *Zelda: Four Swords* with the filename `00000000`, you can rename the file to `Zelda Four Swords.nds`, before placing it inside `/roms/dsi`
 
-        DSi-Enhanced games, such as *Pokemon - Black Version* are usually built with SDK5.x, which makes them a good candidate for usage as a donor ROM. You can check the SDK version of any game by highlighting it in TWiLight and pressing `Y`.
+    1. You will now need to find a DS game built with SDK 5.x to use as a donor ROM for DSiWare. Place the donor ROM in `/roms/nds`.
 
-1. Highlight the donor game in TWiLight, and press `Y` to open the ROM info menu. Scroll down to the bottom, and select `Set as Donor ROM`.
+        !!! tip
+            ![SDK5](../images/donor_info.png){align=left width="115"}
 
-1. You are now ready to play DSiWare! Head to `/roms/dsiware` in TWiLight and choose a game to launch.
+            DSi-Enhanced games, such as *Pokémon: Black Version* are usually built with SDK5.x, which makes them a good candidate for usage as a donor ROM. You can check the SDK version of any game by highlighting it in TWiLight and pressing `Y`.
 
-1. **[Optional]** - To improve compatibility, insert a Slot-2 Memory Expansion Pak if you are using a DS Lite or NDS.
+    1. Highlight the donor game in TWiLight, and press `Y` to open the ROM info menu. Scroll down to the bottom, and select `Set as Donor ROM`.
+
+    1. You are now ready to play DSiWare! Head to `/roms/dsi` in TWiLight and choose a game to launch.
+
+    1. **[Optional]** - To improve compatibility, insert a Slot-2 Memory Expansion Pak if you are using a DS Lite or NDS.
+
+=== "Flashcart Kernels"
+
+    1. Download [NDSForwarder-DSi](https://github.com/lifehackerhansol/NDSForwarder-DSi/releases/latest/download/NDSForwarder.nds) to the flashcart's SD card root
+
+    1. Download the [nds-bootstrap forwarder pack](https://github.com/RocketRobz/NTR_Forwarder/releases/latest/download/DS.Game.Forwarder.pack.nds-bootstrap.7z)
+
+    1. Extract the contents of the `for SD Card root` folder to the root of your flashcart's SD card
+
+    1. After setting up the nds-bootstrap forwarder pack, you will need to place your DSiWare (with `.nds` extension) in `/roms/dsi` on your SD card.
+
+        !!! note
+
+            If your DSiWare dump is a file with no file extension, you can change the filename and add `.nds` to the end to get both NDSForwarder-DSi and the flashcart kernel to pick it up.
+
+            For example, if you have a DSiWare dump of *Zelda: Four Swords* with the filename `00000000`, you can rename the file to `Zelda Four Swords.nds`, before placing it inside `/roms/dsi`
+
+    1. You will now need to find a DS game built with SDK 5.x to use as a donor ROM for DSiWare. Place the donor ROM in `/roms/nds`.
+
+        DSi-Enhanced games, such as *Pokémon: Black Version* are usually built with SDK5.x, which makes them a good candidate for usage as a donor ROM.
+
+    === "Setting a Donor ROM"
+
+        1. Launch `NDSForwarder.nds`
+
+        1. Press `A` on `Install`
+
+        1. Navigate to the donor game's location, press `A`, and select `Install`.
+
+        1. In the flashcart kernel, head to `/forwarders` and choose the donor game to launch.
+
+        1. Hold the `Y` button to open a menu where you can then set the game as a donor ROM.
+
+    === "Adding a DSiWare title"
+
+        1. Launch `NDSForwarder.nds`
+
+        1. Press `A` on `Install`
+
+        1. Navigate to the DSiWare's location, press `A`, and select `Install`.
+
+        1. You are now ready to play DSiWare! Head to `/forwarders` in the flashcart kernel and choose a game to launch.
+
+        1. **[Optional]** - To improve compatibility, insert a Slot-2 Memory Expansion Pak if you are using a DS Lite or NDS.


### PR DESCRIPTION
The following changes have been made:
- Updated warning:
    - Fixed a typo
    - Some games will play without audio
    - Only a few games will occasionally run with slowdown
    - Changed the example of a game needing the Memory Expansion Pak (*Zelda: Four Swords* now boots without it, so *Dragon Quest Wars* is used instead)
- Updated the DSiWare ROM path from `/roms/dsiware` to `/roms/dsi`.
- Added a section for using the flashcard kernel to run DSiWare via nds-bootstrap forwarders